### PR TITLE
Remove icon

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -1,7 +1,6 @@
 ---
 name: Extend env plugin
 authors: Woodpecker Authors
-icon: https://woodpecker-ci.org/img/logo.svg
 description: Extend your .env file with additional variables like semver information.
 tags: [env, semver]
 containerImage: woodpeckerci/plugin-extend-env


### PR DESCRIPTION
Instead of adding our main icon, use the default one by removing it.

This plugin does not have an icon and probably will never have one because it's too generic.