### PR TITLE
Exclude changelog from mdlint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
     rev: v0.39.0
     hooks:
       - id: markdownlint
+        exclude: '^CHANGELOG.md$'
   - repo: https://github.com/mrtazz/checkmake
     rev: 0.2.2
     hooks:


### PR DESCRIPTION
to fix failures in https://github.com/woodpecker-ci/plugin-extend-env/pull/22